### PR TITLE
chore: Update for WSL, python3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Minimal WebPush Topic Demo
+# Minimal WebPush Topic Demo
 
 This is a suite of things to help show how sites can use WebPush topics.
 
@@ -14,27 +14,33 @@ themselves if the user hasn't gotten them yet. Think of messages like "You have
 
   In addition, you'll need to either serve the `./page` directory from your
   local web server or run `bin/topic_server` with enough privileges to be able
-  to start a web server at port 80 (default port is: 8200). This is because of
+  to start a web server at port 80 (default port is: *8200*). This is
+  because of
   a restriction enforced by ServiceWorkers. ServiceWorker scripts must either
   be served from a secure server (one that can run `https://` or from `localhost`)
 
 ### Prerequisites
 
-  Twisted currently requires Python 2.7
+  * `build-essential` or equivalent cc, make, etc. meta package
+  * libssl-dev
+  * $PYTHON development libraries (e.g. `pypy-dev`)
 
 ### Setup
 
+    PYTHON=pypy
     git clone https://github.com/jrconlin/topics.git
     cd topics
-    virtualenv . 
-    source bin/activate
+    virtualenv -p $PYTHON venv
+    source venv/bin/activate
     python setup.py develop
-    bin/topic_server
+    venv/bin/topic_server
 
 
- Now start your browser and go to the topic `page` being served. (Again,
- either this is under a server running on your local machine, or by running
- `bin/topic_server -p 80`)
+ Now start your browser and go to the topic `page` being served.
+ (Again,
+ either this is under a server running on your local machine, or by
+ running
+ `bin/topic_server -p 8200`)
 
  The page is fairly self explanatory, but basically, click on the ***Subscribe***
  button, and say "Allow" when prompted.
@@ -76,11 +82,11 @@ Then re-run:
     python setup.py develop
 
 
-### OSX Users - SSL error 
+### OSX Users - SSL error
 
 Apple has deprecated OpenSSL in favor of its own TLS and crypto libraries.
 If you get an SSL error on OSX (El Capitan), install OpenSSL with brew, then
-link brew libraries and install cryptography.  
+link brew libraries and install cryptography.
 NOTE: /usr/local/opt/openssl is symlinked to brew Cellar:
 
 
@@ -90,5 +96,5 @@ NOTE: /usr/local/opt/openssl is symlinked to brew Cellar:
 
 Then re-run:
 
-    python setup.py develop 
+    python setup.py develop
 

--- a/page/index.html
+++ b/page/index.html
@@ -64,15 +64,24 @@
 
      function subscribe() {
          navigator.serviceWorker.ready.then(function (swr) {
-             return swr.pushManager.subscribe();
-         })
-         .then(function (sub_info) {
-             console.debug(sub_info);
-             document.getElementById("first").classList.add("hidden");
-             return sendSubscription(sub_info);
-         })
-         .catch(function (err) {
-             show_err("Failed to send subscription", err);
+             return swr.pushManager.getSubscription()
+                .then(async function (sub_info) {
+                    if (sub_info) {
+                        return sub_info;
+                    }
+                    console.debug("Previous subscription info: ", sub_info);
+                    document.getElementById("first").classList.add("hidden");
+                    return  swr.pushManager.subscribe({
+                        userVisibleOnly: true
+                    })
+                })
+                .then(function(subscription){
+                    console.debug("sending Subscription", subscription);
+                    self.sendSubscription(subscription)
+                })
+                .catch(function (err) {
+                    show_err("Failed to send subscription", err);
+                });
          });
      }
 

--- a/push_server/handler.py
+++ b/push_server/handler.py
@@ -34,7 +34,7 @@ class MainHandler(cyclone.web.StaticFileHandler):
             body = json.loads(self.request.body)
             out = os.open(self._settings.storage,
                           os.O_RDWR|os.O_CREAT|os.O_TRUNC,
-                          0644)
+                          0o0644)
             # Log generates a false info because it can't format the event
             print("Writing body: {}".format(body))
             os.write(out, self.request.body)

--- a/push_server/log.py
+++ b/push_server/log.py
@@ -14,7 +14,7 @@ class LogObserver(log.FileLogObserver):
         printable = {}
         output = self._format(event)
 
-        self._output.write(unicode(output))
+        self._output.write(output)
 
 
     def start(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,9 @@
+attrs
+cryptography
+ipaddress
+pyasn1
 pywebpush
 configargparse
 cyclone
-twisted
+twisted==19.2.1
 service_identity


### PR DESCRIPTION
* Updated README to include add'l core installs
* Updated requirements.txt to force twisted version and include missing
bits.
* NOTE: until autopush-rs 1.55 goes out, firefox 75+ may need to disable `dom.security.secFetch.enabled`

Closes #8